### PR TITLE
Improve iam

### DIFF
--- a/modules/alert-policies/README.md
+++ b/modules/alert-policies/README.md
@@ -11,14 +11,14 @@
 
 | Name | Type |
 |------|------|
-| [google_monitoring_alert_policy.cpu_utilization_alert_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.alert_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_notification_channel.email_channels](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_notification_channel) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alert_policies"></a> [alert\_policies](#input\_alert\_policies) | A list of alert policies for log-based metrics, each containing conditions, thresholds, durations, and other settings. | <pre>list(object({<br>    display_name       = string<br>    metric_type        = string<br>    threshold          = number<br>    duration           = string<br>    comparison         = string<br>    filter             = string<br>    alignment_period   = string<br>    per_series_aligner = string<br>    trigger_count      = number<br>  }))</pre> | n/a | yes |
+| <a name="input_alert_policies"></a> [alert\_policies](#input\_alert\_policies) | A list of alert policies for log-based metrics, each containing conditions, thresholds, durations, and other settings. | <pre>list(object({<br/>    display_name       = string<br/>    metric_type        = string<br/>    threshold          = number<br/>    duration           = string<br/>    comparison         = string<br/>    filter             = string<br/>    alignment_period   = string<br/>    per_series_aligner = string<br/>    trigger_count      = number<br/>  }))</pre> | n/a | yes |
 | <a name="input_emails"></a> [emails](#input\_emails) | A list of email addresses to send notifications to. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the alert policies will be created. | `string` | n/a | yes |
 <!-- END_TF_DOCS -->

--- a/modules/alert-policies/main.tf
+++ b/modules/alert-policies/main.tf
@@ -1,4 +1,4 @@
-resource "google_monitoring_alert_policy" "cpu_utilization_alert_policy" {
+resource "google_monitoring_alert_policy" "alert_policy" {
   count = length(var.alert_policies)
 
   project = var.project_id

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -6,16 +6,19 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_additional_service_accounts"></a> [additional\_service\_accounts](#module\_additional\_service\_accounts) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
+| <a name="module_api"></a> [api](#module\_api) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
 | <a name="module_developer"></a> [developer](#module\_developer) | terraform-google-modules/iam/google//modules/custom_role_iam | ~>7.7.0 |
 | <a name="module_gitlab"></a> [gitlab](#module\_gitlab) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
-| <a name="module_storage"></a> [storage](#module\_storage) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
 | <a name="module_teamlead"></a> [teamlead](#module\_teamlead) | terraform-google-modules/iam/google//modules/projects_iam | ~> 7.7.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_service_accounts"></a> [additional\_service\_accounts](#input\_additional\_service\_accounts) | Additional service accounts | <pre>list(object({<br>    name          = string<br>    description   = string<br>    generate_keys = bool<br>    project_roles = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_additional_service_accounts"></a> [additional\_service\_accounts](#input\_additional\_service\_accounts) | Additional service accounts | <pre>list(object({<br/>    name          = string<br/>    description   = string<br/>    generate_keys = bool<br/>    project_roles = list(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_api_serviceaccount_name"></a> [api\_serviceaccount\_name](#input\_api\_serviceaccount\_name) | name for API Service Account | `string` | n/a | yes |
+| <a name="input_api_serviceaccount_roles"></a> [api\_serviceaccount\_roles](#input\_api\_serviceaccount\_roles) | list of roles for API Service Account | `list(string)` | n/a | yes |
+| <a name="input_create_single_gitlab_account"></a> [create\_single\_gitlab\_account](#input\_create\_single\_gitlab\_account) | Whether to create single gitlab service account | `bool` | `false` | no |
 | <a name="input_developer_members"></a> [developer\_members](#input\_developer\_members) | List of members for developer role | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id where service account will be created | `string` | n/a | yes |
 | <a name="input_teamlead_members"></a> [teamlead\_members](#input\_teamlead\_members) | List of members for teamlead role | `list(string)` | `[]` | no |
@@ -25,8 +28,8 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_additional_service_accounts"></a> [additional\_service\_accounts](#output\_additional\_service\_accounts) | Additional service accounts |
+| <a name="output_api_email"></a> [api\_email](#output\_api\_email) | n/a |
+| <a name="output_api_key"></a> [api\_key](#output\_api\_key) | n/a |
 | <a name="output_gitlab_email"></a> [gitlab\_email](#output\_gitlab\_email) | n/a |
 | <a name="output_gitlab_key"></a> [gitlab\_key](#output\_gitlab\_key) | n/a |
-| <a name="output_storage_email"></a> [storage\_email](#output\_storage\_email) | n/a |
-| <a name="output_storage_key"></a> [storage\_key](#output\_storage\_key) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -9,17 +9,24 @@
 | <a name="module_api"></a> [api](#module\_api) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
 | <a name="module_developer"></a> [developer](#module\_developer) | terraform-google-modules/iam/google//modules/custom_role_iam | ~>7.7.0 |
 | <a name="module_gitlab"></a> [gitlab](#module\_gitlab) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
+| <a name="module_gitlab_runner_cd"></a> [gitlab\_runner\_cd](#module\_gitlab\_runner\_cd) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
+| <a name="module_gitlab_runner_ci"></a> [gitlab\_runner\_ci](#module\_gitlab\_runner\_ci) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
 | <a name="module_teamlead"></a> [teamlead](#module\_teamlead) | terraform-google-modules/iam/google//modules/projects_iam | ~> 7.7.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_api_roles"></a> [additional\_api\_roles](#input\_additional\_api\_roles) | List of additional API roles | `list(string)` | `[]` | no |
+| <a name="input_additional_gitlab_cd_roles"></a> [additional\_gitlab\_cd\_roles](#input\_additional\_gitlab\_cd\_roles) | List of additional roles for Gitlab CD runner | `list(string)` | `[]` | no |
+| <a name="input_additional_gitlab_ci_roles"></a> [additional\_gitlab\_ci\_roles](#input\_additional\_gitlab\_ci\_roles) | List of additional roles for Gitlab CI runner | `list(string)` | `[]` | no |
 | <a name="input_additional_service_accounts"></a> [additional\_service\_accounts](#input\_additional\_service\_accounts) | Additional service accounts | <pre>list(object({<br/>    name          = string<br/>    description   = string<br/>    generate_keys = bool<br/>    project_roles = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_api_serviceaccount_name"></a> [api\_serviceaccount\_name](#input\_api\_serviceaccount\_name) | name for API Service Account | `string` | n/a | yes |
-| <a name="input_api_serviceaccount_roles"></a> [api\_serviceaccount\_roles](#input\_api\_serviceaccount\_roles) | list of roles for API Service Account | `list(string)` | n/a | yes |
 | <a name="input_create_single_gitlab_account"></a> [create\_single\_gitlab\_account](#input\_create\_single\_gitlab\_account) | Whether to create single gitlab service account | `bool` | `false` | no |
 | <a name="input_developer_members"></a> [developer\_members](#input\_developer\_members) | List of members for developer role | `list(string)` | `[]` | no |
+| <a name="input_generate_api_keys"></a> [generate\_api\_keys](#input\_generate\_api\_keys) | Whether to generate keys for gitlab CD service account | `bool` | `false` | no |
+| <a name="input_generate_gitlab_cd_keys"></a> [generate\_gitlab\_cd\_keys](#input\_generate\_gitlab\_cd\_keys) | Whether to generate keys for gitlab CD service account | `bool` | `false` | no |
+| <a name="input_generate_gitlab_ci_keys"></a> [generate\_gitlab\_ci\_keys](#input\_generate\_gitlab\_ci\_keys) | Whether to generate keys for gitlab CI service account | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id where service account will be created | `string` | n/a | yes |
 | <a name="input_teamlead_members"></a> [teamlead\_members](#input\_teamlead\_members) | List of members for teamlead role | `list(string)` | `[]` | no |
 
@@ -32,4 +39,6 @@
 | <a name="output_api_key"></a> [api\_key](#output\_api\_key) | n/a |
 | <a name="output_gitlab_email"></a> [gitlab\_email](#output\_gitlab\_email) | n/a |
 | <a name="output_gitlab_key"></a> [gitlab\_key](#output\_gitlab\_key) | n/a |
+| <a name="output_gitlab_runner_cd_key"></a> [gitlab\_runner\_cd\_key](#output\_gitlab\_runner\_cd\_key) | n/a |
+| <a name="output_gitlab_runner_ci_key"></a> [gitlab\_runner\_ci\_key](#output\_gitlab\_runner\_ci\_key) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -8,18 +8,20 @@ module "gitlab" {
   project_roles = ["${var.project_id}=>roles/editor"]
 }
 
-module "storage" {
+module "api" {
   source        = "terraform-google-modules/service-accounts/google"
   version       = "~>4.2.1"
   project_id    = var.project_id
-  names         = ["storage"]
-  description   = "Service account for managing storage buckets"
+  names         = [var.api_serviceaccount_name]
+  description   = "Service account for API"
   generate_keys = true
-  project_roles = ["${var.project_id}=>roles/storage.admin"]
+  project_roles = [
+    for role in var.api_serviceaccount_roles : "${var.project_id}=>${role}"
+  ]
 }
 
 module "additional_service_accounts" {
-  for_each     = { for account in var.additional_service_accounts : account.name => account }
+  for_each      = { for account in var.additional_service_accounts : account.name => account }
   source        = "terraform-google-modules/service-accounts/google"
   version       = "~>4.2.1"
   project_id    = var.project_id

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -6,6 +6,7 @@ module "gitlab" {
   description   = "Service account for Gitlab CI/CD"
   generate_keys = true
   project_roles = ["${var.project_id}=>roles/editor"]
+  count         = var.create_single_gitlab_account ? 1 : 0
 }
 
 module "api" {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -16,9 +16,10 @@ module "api" {
   names         = [var.api_serviceaccount_name]
   description   = "Service account for API"
   generate_keys = var.generate_api_keys
-  project_roles = [
-    for role in var.api_serviceaccount_roles : "${var.project_id}=>${role}"
-  ]
+  project_roles = concat(
+    ["${var.project_id}=>roles/storage.admin"],
+    formatlist("${var.project_id}=>%s", var.additional_api_roles)
+  )
 }
 
 module "gitlab_runner_ci" {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -15,10 +15,38 @@ module "api" {
   project_id    = var.project_id
   names         = [var.api_serviceaccount_name]
   description   = "Service account for API"
-  generate_keys = true
+  generate_keys = var.generate_api_keys
   project_roles = [
     for role in var.api_serviceaccount_roles : "${var.project_id}=>${role}"
   ]
+}
+
+module "gitlab_runner_ci" {
+  source        = "terraform-google-modules/service-accounts/google"
+  version       = "~>4.2.1"
+  project_id    = var.project_id
+  names         = ["gitlab"]
+  description   = "Service account for Gitlab CI"
+  generate_keys = var.generate_gitlab_ci_keys
+  project_roles = concat(
+    ["${var.project_id}=>roles/artifactregistry.admin"],
+    formatlist("${var.project_id}=>%s", var.additional_gitlab_ci_roles)
+  )
+  count = var.create_single_gitlab_account ? 0 : 1
+}
+
+module "gitlab_runner_cd" {
+  source        = "terraform-google-modules/service-accounts/google"
+  version       = "~>4.2.1"
+  project_id    = var.project_id
+  names         = ["gitlab"]
+  description   = "Service account for Gitlab CD"
+  generate_keys = var.generate_gitlab_cd_keys
+  project_roles = concat(
+    ["${var.project_id}=>roles/roles/container.admin"],
+    formatlist("${var.project_id}=>%s", var.additional_gitlab_cd_roles)
+  )
+  count = var.create_single_gitlab_account ? 0 : 1
 }
 
 module "additional_service_accounts" {

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -1,9 +1,9 @@
 output "gitlab_email" {
-  value = module.gitlab.email
+  value = module.gitlab[0].email
 }
 
 output "gitlab_key" {
-  value     = module.gitlab.key
+  value     = module.gitlab[0].key
   sensitive = true
 }
 

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -7,17 +7,17 @@ output "gitlab_key" {
   sensitive = true
 }
 
-output "storage_email" {
-  value = module.storage.email
+output "api_email" {
+  value = module.api.email
 }
 
-output "storage_key" {
-  value     = module.storage.key
+output "api_key" {
+  value     = module.api.key
   sensitive = true
 }
 
 output "additional_service_accounts" {
-  value = module.additional_service_accounts
+  value       = module.additional_service_accounts
   description = "Additional service accounts"
-  sensitive = true
+  sensitive   = true
 }

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -1,9 +1,9 @@
 output "gitlab_email" {
-  value = module.gitlab[0].email
+  value = var.create_single_gitlab_account ? module.gitlab[0].email : "Account not created"
 }
 
 output "gitlab_key" {
-  value     = module.gitlab[0].key
+  value     = var.create_single_gitlab_account ? module.gitlab[0].key : "Account not created"
   sensitive = true
 }
 
@@ -20,4 +20,13 @@ output "additional_service_accounts" {
   value       = module.additional_service_accounts
   description = "Additional service accounts"
   sensitive   = true
+}
+
+output "gitlab_runner_ci_key" {
+  value     = !var.create_single_gitlab_account ? module.gitlab_runner_ci[0].key : "Account not created"
+  sensitive = true
+}
+output "gitlab_runner_cd_key" {
+  value     = !var.create_single_gitlab_account ? module.gitlab_runner_cd[0].key : "Account not created"
+  sensitive = true
 }

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -36,6 +36,12 @@ variable "api_serviceaccount_roles" {
   type        = list(string)
 }
 
+variable "additional_api_roles" {
+  description = "List of additional API roles"
+  type        = list(string)
+  default     = []
+}
+
 variable "generate_api_keys" {
   description = "Whether to generate keys for gitlab CD service account"
   type        = bool

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -25,3 +25,19 @@ variable "additional_service_accounts" {
   }))
   default = []
 }
+
+variable "api_serviceaccount_name" {
+  description = "name for API Service Account"
+  type        = string
+}
+
+variable "api_serviceaccount_roles" {
+  description = "list of roles for API Service Account"
+  type        = list(string)
+}
+
+variable "create_single_gitlab_account" {
+  description = "Whether to create single gitlab service account"
+  type        = bool
+  default     = false
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -31,11 +31,6 @@ variable "api_serviceaccount_name" {
   type        = string
 }
 
-variable "api_serviceaccount_roles" {
-  description = "list of roles for API Service Account"
-  type        = list(string)
-}
-
 variable "additional_api_roles" {
   description = "List of additional API roles"
   type        = list(string)

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -36,8 +36,38 @@ variable "api_serviceaccount_roles" {
   type        = list(string)
 }
 
+variable "generate_api_keys" {
+  description = "Whether to generate keys for gitlab CD service account"
+  type        = bool
+  default     = false
+}
+
 variable "create_single_gitlab_account" {
   description = "Whether to create single gitlab service account"
   type        = bool
   default     = false
+}
+
+variable "generate_gitlab_ci_keys" {
+  description = "Whether to generate keys for gitlab CI service account"
+  type        = bool
+  default     = false
+}
+
+variable "generate_gitlab_cd_keys" {
+  description = "Whether to generate keys for gitlab CD service account"
+  type        = bool
+  default     = false
+}
+
+variable "additional_gitlab_ci_roles" {
+  description = "List of additional roles for Gitlab CI runner"
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_gitlab_cd_roles" {
+  description = "List of additional roles for Gitlab CD runner"
+  type        = list(string)
+  default     = []
 }

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -29,6 +29,7 @@ variable "additional_service_accounts" {
 variable "api_serviceaccount_name" {
   description = "name for API Service Account"
   type        = string
+  default     = "api"
 }
 
 variable "additional_api_roles" {


### PR DESCRIPTION
This pull request contains slight improvements like:
1) In IAM, there is now a flag indicating whether to create a single GitLab account or two separate ones (for CI and CD) via the "additional service accounts" section of the module.
2) In IAM, the module "storage" is renamed to "api" to better reflect the account that uses these permissions rather than the role. Additionally, account roles are now a variable.
3) In alert policies, the policy resource name has been changed to better indicate its purpose.