### PR TITLE
Compute instances

### DIFF
--- a/modules/compute-instances/README.md
+++ b/modules/compute-instances/README.md
@@ -1,0 +1,54 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_address.vm_static_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_firewall.vm_custom_egress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.vm_custom_ingress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_instance.vm_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_default_ssh_user"></a> [default\_ssh\_user](#input\_default\_ssh\_user) | Default SSH user for backward compatibility when using ssh\_public\_keys | `string` | `"ubuntu"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to all resources created by this module | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | The network to deploy the instances in. | `string` | n/a | yes |
+| <a name="input_network_tag"></a> [network\_tag](#input\_network\_tag) | Tag used to identify the VM instances for firewall rules. | `string` | `"vms"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to deploy the resources in. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region where the static IPs will be created. | `string` | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Email of the service account to attach to the VMs. | `string` | n/a | yes |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | Global SSH keys to add to all VMs (unless overridden by per-VM keys) | <pre>list(object({<br/>    user = string<br/>    key  = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_ssh_public_keys"></a> [ssh\_public\_keys](#input\_ssh\_public\_keys) | List of SSH public keys to add to all VMs with default user (backward compatibility) | `list(string)` | `[]` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self-link of the subnetwork to use. | `string` | n/a | yes |
+| <a name="input_vms"></a> [vms](#input\_vms) | A list of objects defining the VMs to create. | <pre>list(object({<br/>    name             = string<br/>    machine_type     = string<br/>    disk_size_gb     = number<br/>    disk_type        = string<br/>    source_image     = string<br/>    assign_static_ip = bool<br/>    static_ip_name   = optional(string)<br/>    startup_script   = string<br/>    ssh_keys = optional(list(object({<br/>      user = string<br/>      key  = string<br/>    })), [])<br/>    ingress_rules = optional(list(object({<br/>      protocol      = string<br/>      ports         = list(string)<br/>      source_ranges = list(string)<br/>    })), [])<br/>    egress_rules = optional(list(object({<br/>      protocol           = string<br/>      ports              = list(string)<br/>      destination_ranges = list(string)<br/>    })), [])<br/>  }))</pre> | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | The zone where the instances will be deployed. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_external_ips"></a> [external\_ips](#output\_external\_ips) | Map of VM names to their external IP addresses (if any) |
+| <a name="output_instance_external_ips"></a> [instance\_external\_ips](#output\_instance\_external\_ips) | List of external IP addresses (for backward compatibility) |
+| <a name="output_instance_ids"></a> [instance\_ids](#output\_instance\_ids) | Map of VM names to their instance IDs |
+| <a name="output_instance_names"></a> [instance\_names](#output\_instance\_names) | List of VM instance names |
+| <a name="output_instance_self_links"></a> [instance\_self\_links](#output\_instance\_self\_links) | Map of VM names to their self links |
+| <a name="output_instance_zones"></a> [instance\_zones](#output\_instance\_zones) | Map of VM names to their zones |
+| <a name="output_internal_ips"></a> [internal\_ips](#output\_internal\_ips) | Map of VM names to their internal IP addresses |
+| <a name="output_network_tag"></a> [network\_tag](#output\_network\_tag) | The network tag used for the VMs |
+| <a name="output_static_ips"></a> [static\_ips](#output\_static\_ips) | Map of VM names to their static IP addresses |
+<!-- END_TF_DOCS -->

--- a/modules/compute-instances/main.tf
+++ b/modules/compute-instances/main.tf
@@ -1,0 +1,170 @@
+locals {
+  vms_with_static_ip = {
+    for vm in var.vms : vm.name => vm
+    if vm.assign_static_ip
+  }
+
+  ssh_keys_metadata = {
+    for vm in var.vms : vm.name => (
+      length(vm.ssh_keys) > 0 ? join("\n", [for ssh_key in vm.ssh_keys : "${ssh_key.user}:${ssh_key.key}"]) :
+      length(var.ssh_keys) > 0 ? join("\n", [for ssh_key in var.ssh_keys : "${ssh_key.user}:${ssh_key.key}"]) :
+      length(var.ssh_public_keys) > 0 ? join("\n", [for key in var.ssh_public_keys : "${var.default_ssh_user}:${key}"]) :
+      ""
+    )
+  }
+
+  firewall_prefix = var.project_id != "" ? "${var.project_id}-" : ""
+}
+
+resource "google_compute_address" "vm_static_ip" {
+  for_each = local.vms_with_static_ip
+
+  name        = each.value.static_ip_name
+  project     = var.project_id
+  region      = var.region
+  description = "Static IP for VM instance: ${each.value.name}"
+
+  labels = merge(
+    var.labels,
+    {
+      vm_name    = each.value.name
+      managed_by = "terraform"
+    }
+  )
+}
+
+resource "google_compute_instance" "vm_instance" {
+  for_each = { for vm in var.vms : vm.name => vm }
+
+  project                   = var.project_id
+  zone                      = var.zone
+  name                      = each.value.name
+  machine_type              = each.value.machine_type
+  tags                      = [var.network_tag]
+  allow_stopping_for_update = true
+  description               = "Managed by Terraform - VM instance: ${each.value.name}"
+
+  boot_disk {
+    initialize_params {
+      image = each.value.source_image
+      size  = each.value.disk_size_gb
+      type  = each.value.disk_type
+
+      labels = merge(
+        var.labels,
+        {
+          vm_name    = each.value.name
+          managed_by = "terraform"
+        }
+      )
+    }
+  }
+
+  network_interface {
+    network    = var.network
+    subnetwork = var.subnetwork_self_link
+    access_config {
+      nat_ip = each.value.assign_static_ip ? google_compute_address.vm_static_ip[each.value.name].address : null
+    }
+  }
+
+  metadata = merge(
+    local.ssh_keys_metadata[each.value.name] != "" ? {
+      ssh-keys = local.ssh_keys_metadata[each.value.name]
+    } : {},
+    each.value.startup_script != "" ? {
+      startup-script = each.value.startup_script
+    } : {}
+  )
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  labels = merge(
+    var.labels,
+    {
+      vm_name    = each.value.name
+      managed_by = "terraform"
+    }
+  )
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_compute_firewall" "vm_custom_ingress" {
+  for_each = {
+    for rule_key, rule_value in flatten([
+      for vm in var.vms : [
+        for rule_index, rule in vm.ingress_rules : {
+          vm_name = vm.name
+          rule    = rule
+          key     = "${local.firewall_prefix}${vm.name}-ingress-${rule_index}"
+        }
+      ]
+    ]) : rule_value.key => rule_value
+  }
+
+  name        = each.key
+  network     = var.network
+  project     = var.project_id
+  description = "Ingress rule for VM: ${each.value.vm_name} - Protocol: ${each.value.rule.protocol}"
+
+  allow {
+    protocol = each.value.rule.protocol
+    ports    = each.value.rule.ports
+  }
+
+  direction     = "INGRESS"
+  source_ranges = each.value.rule.source_ranges
+  target_tags   = [var.network_tag]
+
+  labels = merge(
+    var.labels,
+    {
+      vm_name    = each.value.vm_name
+      managed_by = "terraform"
+      rule_type  = "ingress"
+    }
+  )
+}
+
+resource "google_compute_firewall" "vm_custom_egress" {
+  for_each = {
+    for rule_key, rule_value in flatten([
+      for vm in var.vms : [
+        for rule_index, rule in vm.egress_rules : {
+          vm_name = vm.name
+          rule    = rule
+          key     = "${local.firewall_prefix}${vm.name}-egress-${rule_index}"
+        }
+      ]
+    ]) : rule_value.key => rule_value
+  }
+
+  name        = each.key
+  network     = var.network
+  project     = var.project_id
+  description = "Egress rule for VM: ${each.value.vm_name} - Protocol: ${each.value.rule.protocol}"
+
+  allow {
+    protocol = each.value.rule.protocol
+    ports    = each.value.rule.ports
+  }
+
+  direction          = "EGRESS"
+  destination_ranges = each.value.rule.destination_ranges
+  target_tags        = [var.network_tag]
+
+  labels = merge(
+    var.labels,
+    {
+      vm_name    = each.value.vm_name
+      managed_by = "terraform"
+      rule_type  = "egress"
+    }
+  )
+}

--- a/modules/compute-instances/main.tf
+++ b/modules/compute-instances/main.tf
@@ -63,8 +63,12 @@ resource "google_compute_instance" "vm_instance" {
   network_interface {
     network    = var.network
     subnetwork = var.subnetwork_self_link
-    access_config {
-      nat_ip = each.value.assign_static_ip ? google_compute_address.vm_static_ip[each.value.name].address : null
+
+    dynamic "access_config" {
+      for_each = each.value.assign_static_ip ? [1] : []
+      content {
+        nat_ip = google_compute_address.vm_static_ip[each.value.name].address
+      }
     }
   }
 

--- a/modules/compute-instances/outputs.tf
+++ b/modules/compute-instances/outputs.tf
@@ -1,0 +1,68 @@
+output "instance_ids" {
+  description = "Map of VM names to their instance IDs"
+  value = {
+    for name, instance in google_compute_instance.vm_instance :
+    name => instance.id
+  }
+}
+
+output "instance_self_links" {
+  description = "Map of VM names to their self links"
+  value = {
+    for name, instance in google_compute_instance.vm_instance :
+    name => instance.self_link
+  }
+}
+
+output "instance_names" {
+  description = "List of VM instance names"
+  value = [
+    for name, instance in google_compute_instance.vm_instance :
+    instance.name
+  ]
+}
+
+output "internal_ips" {
+  description = "Map of VM names to their internal IP addresses"
+  value = {
+    for name, instance in google_compute_instance.vm_instance :
+    name => instance.network_interface[0].network_ip
+  }
+}
+
+output "external_ips" {
+  description = "Map of VM names to their external IP addresses (if any)"
+  value = {
+    for name, instance in google_compute_instance.vm_instance :
+    name => try(instance.network_interface[0].access_config[0].nat_ip, null)
+  }
+}
+
+output "static_ips" {
+  description = "Map of VM names to their static IP addresses"
+  value = {
+    for name, ip in google_compute_address.vm_static_ip :
+    name => ip.address
+  }
+}
+
+output "instance_zones" {
+  description = "Map of VM names to their zones"
+  value = {
+    for name, instance in google_compute_instance.vm_instance :
+    name => instance.zone
+  }
+}
+
+output "instance_external_ips" {
+  description = "List of external IP addresses (for backward compatibility)"
+  value = [
+    for vm_ip in google_compute_address.vm_static_ip :
+    vm_ip.address
+  ]
+}
+
+output "network_tag" {
+  description = "The network tag used for the VMs"
+  value       = var.network_tag
+}

--- a/modules/compute-instances/variables.tf
+++ b/modules/compute-instances/variables.tf
@@ -30,12 +30,12 @@ variable "vms" {
     })), [])
     ingress_rules = optional(list(object({
       protocol      = string
-      ports         = list(string)
+      ports         = optional(list(string))
       source_ranges = list(string)
     })), [])
     egress_rules = optional(list(object({
       protocol           = string
-      ports              = list(string)
+      ports              = optional(list(string))
       destination_ranges = list(string)
     })), [])
   }))

--- a/modules/compute-instances/variables.tf
+++ b/modules/compute-instances/variables.tf
@@ -1,0 +1,149 @@
+variable "project_id" {
+  description = "The project ID to deploy the resources in."
+  type        = string
+}
+
+variable "region" {
+  description = "The region where the static IPs will be created."
+  type        = string
+}
+
+variable "zone" {
+  description = "The zone where the instances will be deployed."
+  type        = string
+}
+
+variable "vms" {
+  description = "A list of objects defining the VMs to create."
+  type = list(object({
+    name             = string
+    machine_type     = string
+    disk_size_gb     = number
+    disk_type        = string
+    source_image     = string
+    assign_static_ip = bool
+    static_ip_name   = optional(string)
+    startup_script   = string
+    ssh_keys = optional(list(object({
+      user = string
+      key  = string
+    })), [])
+    ingress_rules = optional(list(object({
+      protocol      = string
+      ports         = list(string)
+      source_ranges = list(string)
+    })), [])
+    egress_rules = optional(list(object({
+      protocol           = string
+      ports              = list(string)
+      destination_ranges = list(string)
+    })), [])
+  }))
+
+  validation {
+    condition = alltrue([
+      for vm in var.vms : can(regex("^[a-z][-a-z0-9]*[a-z0-9]$", vm.name))
+    ])
+    error_message = "VM names must start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, and hyphens."
+  }
+
+  validation {
+    condition = alltrue([
+      for vm in var.vms : vm.disk_size_gb >= 10 && vm.disk_size_gb <= 65536
+    ])
+    error_message = "Disk size must be between 10 GB and 65536 GB."
+  }
+
+  validation {
+    condition = alltrue([
+      for vm in var.vms : contains(["pd-standard", "pd-ssd", "pd-balanced"], vm.disk_type)
+    ])
+    error_message = "Disk type must be one of: pd-standard, pd-ssd, pd-balanced."
+  }
+
+  validation {
+    condition = alltrue([
+      for vm in var.vms : !vm.assign_static_ip || (vm.assign_static_ip && vm.static_ip_name != null && vm.static_ip_name != "")
+    ])
+    error_message = "static_ip_name must be provided when assign_static_ip is true."
+  }
+
+  validation {
+    condition = alltrue([
+      for vm in var.vms : length(vm.name) <= 63
+    ])
+    error_message = "VM names must be 63 characters or less."
+  }
+
+  validation {
+    condition     = length(var.vms) == length(distinct([for vm in var.vms : vm.name]))
+    error_message = "All VM names must be unique."
+  }
+}
+
+variable "network" {
+  description = "The network to deploy the instances in."
+  type        = string
+}
+
+variable "subnetwork_self_link" {
+  description = "The self-link of the subnetwork to use."
+  type        = string
+}
+
+variable "network_tag" {
+  description = "Tag used to identify the VM instances for firewall rules."
+  type        = string
+  default     = "vms"
+
+  validation {
+    condition     = can(regex("^[a-z][-a-z0-9]*$", var.network_tag))
+    error_message = "Network tag must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "service_account_email" {
+  description = "Email of the service account to attach to the VMs."
+  type        = string
+}
+
+variable "ssh_keys" {
+  description = "Global SSH keys to add to all VMs (unless overridden by per-VM keys)"
+  type = list(object({
+    user = string
+    key  = string
+  }))
+  default = []
+}
+
+variable "default_ssh_user" {
+  description = "Default SSH user for backward compatibility when using ssh_public_keys"
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_public_keys" {
+  description = "List of SSH public keys to add to all VMs with default user (backward compatibility)"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Labels to apply to all resources created by this module"
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.labels : can(regex("^[a-z0-9_-]{1,63}$", k))
+    ])
+    error_message = "Label keys must be lowercase alphanumeric characters, underscores, or hyphens, and 1-63 characters long."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.labels : can(regex("^[a-z0-9_-]{0,63}$", v))
+    ])
+    error_message = "Label values must be lowercase alphanumeric characters, underscores, or hyphens, and 0-63 characters long."
+  }
+}

--- a/modules/compute-instances/variables.tf
+++ b/modules/compute-instances/variables.tf
@@ -97,7 +97,7 @@ variable "network_tag" {
   default     = "vms"
 
   validation {
-    condition     = can(regex("^[a-z][-a-z0-9]*$", var.network_tag))
+    condition     = can(regex("^[a-z][-a-z0-9]*[a-z0-9]$", var.network_tag))
     error_message = "Network tag must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens."
   }
 }

--- a/modules/compute-instances/versions.tf
+++ b/modules/compute-instances/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -96,7 +96,8 @@ module "developer" {
     "cloudsql.instances.connect",
   ]
   excluded_permissions = [
-    "resourcemanager.projects.list"
+    "resourcemanager.projects.list",
+    "eventarc.multiProjectSources.collectGoogleApiEvents"
   ]
   members = var.developer_members
 }

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -26,7 +26,7 @@ module "gitlab_runner_ci" {
   source        = "terraform-google-modules/service-accounts/google"
   version       = "~>4.2.1"
   project_id    = var.project_id
-  names         = ["gitlab"]
+  names         = ["gitlab-ci"]
   description   = "Service account for Gitlab CI"
   generate_keys = var.generate_gitlab_ci_keys
   project_roles = concat(
@@ -40,7 +40,7 @@ module "gitlab_runner_cd" {
   source        = "terraform-google-modules/service-accounts/google"
   version       = "~>4.2.1"
   project_id    = var.project_id
-  names         = ["gitlab"]
+  names         = ["gitlab-cd"]
   description   = "Service account for Gitlab CD"
   generate_keys = var.generate_gitlab_cd_keys
   project_roles = concat(

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -5,7 +5,7 @@ module "gitlab" {
   names         = ["gitlab"]
   description   = "Service account for Gitlab CI/CD"
   generate_keys = true
-  project_roles = ["${var.project_id}=>roles/editor"]
+  project_roles = formatlist("${var.project_id}=>%s", var.gitlab_roles)
   count         = var.create_single_gitlab_account ? 1 : 0
 }
 
@@ -16,10 +16,7 @@ module "api" {
   names         = [var.api_serviceaccount_name]
   description   = "Service account for API"
   generate_keys = var.generate_api_keys
-  project_roles = concat(
-    ["${var.project_id}=>roles/storage.admin"],
-    formatlist("${var.project_id}=>%s", var.additional_api_roles)
-  )
+  project_roles = formatlist("${var.project_id}=>%s", var.api_roles)
 }
 
 module "gitlab_runner_ci" {
@@ -29,11 +26,8 @@ module "gitlab_runner_ci" {
   names         = ["gitlab-ci"]
   description   = "Service account for Gitlab CI"
   generate_keys = var.generate_gitlab_ci_keys
-  project_roles = concat(
-    ["${var.project_id}=>roles/artifactregistry.admin"],
-    formatlist("${var.project_id}=>%s", var.additional_gitlab_ci_roles)
-  )
-  count = var.create_single_gitlab_account ? 0 : 1
+  project_roles = formatlist("${var.project_id}=>%s", var.gitlab_ci_roles)
+  count         = var.create_single_gitlab_account ? 0 : 1
 }
 
 module "gitlab_runner_cd" {
@@ -43,11 +37,8 @@ module "gitlab_runner_cd" {
   names         = ["gitlab-cd"]
   description   = "Service account for Gitlab CD"
   generate_keys = var.generate_gitlab_cd_keys
-  project_roles = concat(
-    ["${var.project_id}=>roles/roles/container.admin"],
-    formatlist("${var.project_id}=>%s", var.additional_gitlab_cd_roles)
-  )
-  count = var.create_single_gitlab_account ? 0 : 1
+  project_roles = formatlist("${var.project_id}=>%s", var.gitlab_cd_roles)
+  count         = var.create_single_gitlab_account ? 0 : 1
 }
 
 module "additional_service_accounts" {

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -32,10 +32,10 @@ variable "api_serviceaccount_name" {
   default     = "api"
 }
 
-variable "additional_api_roles" {
-  description = "List of additional API roles"
+variable "api_roles" {
+  description = "List of roles for API service account (can be fully overridden)"
   type        = list(string)
-  default     = []
+  default     = ["roles/storage.admin"]
 }
 
 variable "generate_api_keys" {
@@ -50,10 +50,22 @@ variable "create_single_gitlab_account" {
   default     = false
 }
 
+variable "gitlab_roles" {
+  description = "List of roles for single Gitlab service account (can be fully overridden)"
+  type        = list(string)
+  default     = ["roles/editor"]
+}
+
 variable "generate_gitlab_ci_keys" {
   description = "Whether to generate keys for gitlab CI service account"
   type        = bool
   default     = false
+}
+
+variable "gitlab_ci_roles" {
+  description = "List of roles for Gitlab CI runner (can be fully overridden)"
+  type        = list(string)
+  default     = ["roles/artifactregistry.admin"]
 }
 
 variable "generate_gitlab_cd_keys" {
@@ -62,14 +74,8 @@ variable "generate_gitlab_cd_keys" {
   default     = false
 }
 
-variable "additional_gitlab_ci_roles" {
-  description = "List of additional roles for Gitlab CI runner"
+variable "gitlab_cd_roles" {
+  description = "List of roles for Gitlab CD runner (can be fully overridden)"
   type        = list(string)
-  default     = []
-}
-
-variable "additional_gitlab_cd_roles" {
-  description = "List of additional roles for Gitlab CD runner"
-  type        = list(string)
-  default     = []
+  default     = ["roles/container.admin"]
 }

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -29,7 +29,7 @@ variable "additional_service_accounts" {
 variable "api_serviceaccount_name" {
   description = "name for API Service Account"
   type        = string
-  default     = "api"
+  default     = "backend"
 }
 
 variable "api_roles" {
@@ -65,7 +65,7 @@ variable "generate_gitlab_ci_keys" {
 variable "gitlab_ci_roles" {
   description = "List of roles for Gitlab CI runner (can be fully overridden)"
   type        = list(string)
-  default     = ["roles/artifactregistry.admin"]
+  default     = ["roles/artifactregistry.admin", "roles/storage.admin", "roles/iam.serviceAccountTokenCreator"]
 }
 
 variable "generate_gitlab_cd_keys" {


### PR DESCRIPTION
Added a new module, compute-instances:

- Creates VMs with custom machine types and disk configurations
- Manages static IPs (only when needed)
- Sets up SSH keys per-VM or globally
- Handles ingress/egress firewall rules
- Attaches service accounts and runs startup scripts
- Input validation catches config errors early
- Labels everything for tracking