### PR TITLE
feat(iam): add read-only agent-viewer service account

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -61,6 +61,26 @@ module "additional_service_accounts" {
   project_roles = [for item in each.value.project_roles : "${var.project_id}=>${item}"]
 }
 
+module "agent_viewer" {
+  source        = "terraform-google-modules/service-accounts/google"
+  version       = "~>4.2.1"
+  project_id    = var.project_id
+  names         = [var.agent_viewer_name]
+  description   = "Read-only identity for AI agents / MCP servers (diagnostics; impersonated, no keys)"
+  generate_keys = false
+  project_roles = [for role in var.agent_viewer_roles : "${var.project_id}=>${role}"]
+  count         = var.create_agent_viewer ? 1 : 0
+}
+
+# Grant the listed principals permission to impersonate the read-only SA
+# (keyless auth: the agent runs as the user and mints short-lived tokens).
+resource "google_service_account_iam_member" "agent_viewer_impersonators" {
+  for_each           = var.create_agent_viewer ? toset(var.agent_viewer_members) : toset([])
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${module.agent_viewer[0].email}"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = each.value
+}
+
 module "teamlead" {
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
   version  = "~> 7.7.0"

--- a/modules/iam/output.tf
+++ b/modules/iam/output.tf
@@ -30,3 +30,8 @@ output "gitlab_runner_cd_key" {
   value     = !var.create_single_gitlab_account ? module.gitlab_runner_cd[0].key : "Account not created"
   sensitive = true
 }
+
+output "agent_viewer_email" {
+  value       = var.create_agent_viewer ? module.agent_viewer[0].email : "Account not created"
+  description = "Email of the read-only agent-viewer service account"
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -15,6 +15,30 @@ variable "developer_members" {
   default     = []
 }
 
+variable "create_agent_viewer" {
+  description = "Whether to create the read-only agent-viewer service account for AI agents / MCP servers"
+  type        = bool
+  default     = false
+}
+
+variable "agent_viewer_name" {
+  description = "Name of the read-only agent-viewer service account"
+  type        = string
+  default     = "agent-viewer"
+}
+
+variable "agent_viewer_roles" {
+  description = "Project roles granted to the agent-viewer service account (read-only by default)"
+  type        = list(string)
+  default     = ["roles/viewer"]
+}
+
+variable "agent_viewer_members" {
+  description = "Members allowed to impersonate the agent-viewer service account, e.g. user:you@example.com"
+  type        = list(string)
+  default     = []
+}
+
 variable "additional_service_accounts" {
   description = "Additional service accounts"
   type = list(object({


### PR DESCRIPTION
## What

Adds an optional **read-only `agent-viewer` service account** to the `iam` module — a keyless identity for AI agents / MCP servers to inspect GCP without being able to mutate it.

- Gated behind `create_agent_viewer` (default `false`) → no effect on existing consumers.
- `generate_keys = false` — no long-lived key; auth is via impersonation.
- `roles/viewer` by default (overridable via `agent_viewer_roles`).
- Grants `roles/iam.serviceAccountTokenCreator` to `agent_viewer_members`, so listed principals can impersonate it (`CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT`) — no key leaves the project.

## New inputs

`create_agent_viewer`, `agent_viewer_name` (default `agent-viewer`), `agent_viewer_roles` (default `["roles/viewer"]`), `agent_viewer_members`.

## New output

`agent_viewer_email`.

## Validation

`terraform fmt -check` clean; `terraform validate` → Success (google provider v5.45.2). No state touched.

> Docs regeneration for this change lives in the stacked PR `chore/terraform-docs-v0.24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
