### PR TITLE
docs: regenerate module READMEs with terraform-docs v0.24.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
+    rev: "v0.24.0"
     hooks:
       - id: terraform-docs-go
         args: ["markdown","--hide-empty=true","-c", ".terraform.docs.yml", "./modules"]

--- a/modules/alert-policies/README.md
+++ b/modules/alert-policies/README.md
@@ -4,20 +4,20 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google_monitoring_alert_policy.alert_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_notification_channel.email_channels](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_notification_channel) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_alert_policies"></a> [alert\_policies](#input\_alert\_policies) | A list of alert policies for log-based metrics, each containing conditions, thresholds, durations, and other settings. | <pre>list(object({<br/>    display_name       = string<br/>    metric_type        = string<br/>    threshold          = number<br/>    duration           = string<br/>    comparison         = string<br/>    filter             = string<br/>    alignment_period   = string<br/>    per_series_aligner = string<br/>    trigger_count      = number<br/>  }))</pre> | n/a | yes |
 | <a name="input_emails"></a> [emails](#input\_emails) | A list of email addresses to send notifications to. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the alert policies will be created. | `string` | n/a | yes |

--- a/modules/artifacts-registry/README.md
+++ b/modules/artifacts-registry/README.md
@@ -4,19 +4,19 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google-beta_google_artifact_registry_repository.docker_repository](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_artifact_registry_repository) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_docker_repository_ids"></a> [docker\_repository\_ids](#input\_docker\_repository\_ids) | List of repository ids to create | `set(string)` | `[]` | no |
 | <a name="input_keep_count"></a> [keep\_count](#input\_keep\_count) | Number of most recent versions to keep | `number` | `10` | no |
 | <a name="input_location"></a> [location](#input\_location) | The name of the location this repository is located in | `string` | `"europe-west2"` | no |

--- a/modules/cloud-sql/postgresql/README.md
+++ b/modules/cloud-sql/postgresql/README.md
@@ -4,13 +4,13 @@
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_this"></a> [this](#module\_this) | GoogleCloudPlatform/sql-db/google//modules/postgresql | 26.2.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_activation_policy"></a> [activation\_policy](#input\_activation\_policy) | The activation policy for the master instance.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | `string` | `"ALWAYS"` | no |
 | <a name="input_additional_databases"></a> [additional\_databases](#input\_additional\_databases) | A list of databases to be created in your cluster | <pre>list(object({<br/>    name      = string<br/>    charset   = string<br/>    collation = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | A list of users to be created in your cluster. A random password would be set for the user if the `random_password` variable is set. | <pre>list(object({<br/>    name            = string<br/>    password        = string<br/>    random_password = bool<br/>  }))</pre> | `[]` | no |
@@ -44,7 +44,7 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_additional_users"></a> [additional\_users](#output\_additional\_users) | List of maps of additional users and passwords |
 | <a name="output_generated_user_password"></a> [generated\_user\_password](#output\_generated\_user\_password) | The auto generated default user password if not input password was provided |
 | <a name="output_iam_users"></a> [iam\_users](#output\_iam\_users) | The list of the IAM users with access to the CloudSQL instance |

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,11 +1,18 @@
 <!-- BEGIN_TF_DOCS -->
 
 
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_additional_service_accounts"></a> [additional\_service\_accounts](#module\_additional\_service\_accounts) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
+| <a name="module_agent_viewer"></a> [agent\_viewer](#module\_agent\_viewer) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
 | <a name="module_api"></a> [api](#module\_api) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
 | <a name="module_developer"></a> [developer](#module\_developer) | terraform-google-modules/iam/google//modules/custom_role_iam | ~>7.7.0 |
 | <a name="module_gitlab"></a> [gitlab](#module\_gitlab) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
@@ -13,15 +20,25 @@
 | <a name="module_gitlab_runner_ci"></a> [gitlab\_runner\_ci](#module\_gitlab\_runner\_ci) | terraform-google-modules/service-accounts/google | ~>4.2.1 |
 | <a name="module_teamlead"></a> [teamlead](#module\_teamlead) | terraform-google-modules/iam/google//modules/projects_iam | ~> 7.7.0 |
 
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_service_account_iam_member.agent_viewer_impersonators](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_api_roles"></a> [additional\_api\_roles](#input\_additional\_api\_roles) | List of additional API roles | `list(string)` | `[]` | no |
 | <a name="input_additional_gitlab_cd_roles"></a> [additional\_gitlab\_cd\_roles](#input\_additional\_gitlab\_cd\_roles) | List of additional roles for Gitlab CD runner | `list(string)` | `[]` | no |
 | <a name="input_additional_gitlab_ci_roles"></a> [additional\_gitlab\_ci\_roles](#input\_additional\_gitlab\_ci\_roles) | List of additional roles for Gitlab CI runner | `list(string)` | `[]` | no |
 | <a name="input_additional_service_accounts"></a> [additional\_service\_accounts](#input\_additional\_service\_accounts) | Additional service accounts | <pre>list(object({<br/>    name          = string<br/>    description   = string<br/>    generate_keys = bool<br/>    project_roles = list(string)<br/>  }))</pre> | `[]` | no |
-| <a name="input_api_serviceaccount_name"></a> [api\_serviceaccount\_name](#input\_api\_serviceaccount\_name) | name for API Service Account | `string` | n/a | yes |
+| <a name="input_agent_viewer_members"></a> [agent\_viewer\_members](#input\_agent\_viewer\_members) | Members allowed to impersonate the agent-viewer service account, e.g. user:you@example.com | `list(string)` | `[]` | no |
+| <a name="input_agent_viewer_name"></a> [agent\_viewer\_name](#input\_agent\_viewer\_name) | Name of the read-only agent-viewer service account | `string` | `"agent-viewer"` | no |
+| <a name="input_agent_viewer_roles"></a> [agent\_viewer\_roles](#input\_agent\_viewer\_roles) | Project roles granted to the agent-viewer service account (read-only by default) | `list(string)` | <pre>[<br/>  "roles/viewer"<br/>]</pre> | no |
+| <a name="input_api_serviceaccount_name"></a> [api\_serviceaccount\_name](#input\_api\_serviceaccount\_name) | name for API Service Account | `string` | `"api"` | no |
+| <a name="input_create_agent_viewer"></a> [create\_agent\_viewer](#input\_create\_agent\_viewer) | Whether to create the read-only agent-viewer service account for AI agents / MCP servers | `bool` | `false` | no |
 | <a name="input_create_single_gitlab_account"></a> [create\_single\_gitlab\_account](#input\_create\_single\_gitlab\_account) | Whether to create single gitlab service account | `bool` | `false` | no |
 | <a name="input_developer_members"></a> [developer\_members](#input\_developer\_members) | List of members for developer role | `list(string)` | `[]` | no |
 | <a name="input_generate_api_keys"></a> [generate\_api\_keys](#input\_generate\_api\_keys) | Whether to generate keys for gitlab CD service account | `bool` | `false` | no |
@@ -33,8 +50,9 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_additional_service_accounts"></a> [additional\_service\_accounts](#output\_additional\_service\_accounts) | Additional service accounts |
+| <a name="output_agent_viewer_email"></a> [agent\_viewer\_email](#output\_agent\_viewer\_email) | Email of the read-only agent-viewer service account |
 | <a name="output_api_email"></a> [api\_email](#output\_api\_email) | n/a |
 | <a name="output_api_key"></a> [api\_key](#output\_api\_key) | n/a |
 | <a name="output_gitlab_email"></a> [gitlab\_email](#output\_gitlab\_email) | n/a |

--- a/modules/ingress-nginx/README.md
+++ b/modules/ingress-nginx/README.md
@@ -4,26 +4,26 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
-| <a name="module_nginx-controller"></a> [nginx-controller](#module\_nginx-controller) | terraform-iaac/nginx-controller/helm | ~>2.2.2 |
+| ---- | ------ | ------- |
+| <a name="module_nginx-controller"></a> [nginx-controller](#module\_nginx-controller) | terraform-iaac/nginx-controller/helm | ~>2.3.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google_compute_address.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_client_config.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_set"></a> [additional\_set](#input\_additional\_set) | Optional set for additional helm settings | <pre>list(<br/>    object(<br/>      {<br/>        name  = string<br/>        value = string<br/>        type  = optional(string)<br/>      }<br/>    )<br/>  )</pre> | <pre>[<br/>  {<br/>    "name": "controller.resources.limits.cpu",<br/>    "type": "string",<br/>    "value": "125m"<br/>  },<br/>  {<br/>    "name": "controller.resources.limits.memory",<br/>    "type": "string",<br/>    "value": "175Mi"<br/>  },<br/>  {<br/>    "name": "controller.config.proxy-body-size",<br/>    "type": "string",<br/>    "value": "100m"<br/>  },<br/>  {<br/>    "name": "controller.addHeaders.x-robots-tag",<br/>    "type": "string",<br/>    "value": "noindex"<br/>  }<br/>]</pre> | no |
 | <a name="input_atomic"></a> [atomic](#input\_atomic) | If set, installation process purges chart on fail | `bool` | `true` | no |
 | <a name="input_ca_certificate"></a> [ca\_certificate](#input\_ca\_certificate) | The CA certificate of the Kubernetes cluster | `string` | n/a | yes |

--- a/modules/log-based-metrics/README.md
+++ b/modules/log-based-metrics/README.md
@@ -4,25 +4,25 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google_logging_metric.log_metric](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_metrics"></a> [metrics](#input\_metrics) | A list of log-based metrics configurations. | <pre>list(object({<br>    metric_name        = string<br>    metric_description = string<br>    filter             = string<br>    metric_kind        = string<br>    value_type         = string<br>    value_extractor    = string<br>    label_extractors   = map(string)<br>  }))</pre> | n/a | yes |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_metrics"></a> [metrics](#input\_metrics) | A list of log-based metrics configurations. | <pre>list(object({<br/>    metric_name        = string<br/>    metric_description = string<br/>    filter             = string<br/>    metric_kind        = string<br/>    value_type         = string<br/>    value_extractor    = string<br/>    label_extractors   = map(string)<br/>  }))</pre> | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the log metric will be created. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_metric_ids"></a> [metric\_ids](#output\_metric\_ids) | IDs of the log-based metrics |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
## What

Bumps the pinned `terraform-docs-go` pre-commit hook **v0.16.0 → v0.24.0** and re-renders all module READMEs so committed docs match the hook output.

> ⚠️ **Stacked on `feat/agent-viewer-sa`** (this PR's base branch). The `iam` README regeneration includes the new `agent-viewer` inputs/outputs, which depend on that PR's code. Review/merge `feat/agent-viewer-sa` first — GitHub will retarget this PR to `main` automatically.

## Changes

- `.pre-commit-config.yaml`: hook `rev` → `v0.24.0`.
- All module READMEs re-rendered (table-separator format change from the newer terraform-docs).
- Syncs a few stale entries to current code: `iam` `api_serviceaccount_name` default, `ingress-nginx` `nginx-controller` version; documents the new `iam` `agent-viewer` SA.
- Drops an empty generated `modules/README.md` stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
